### PR TITLE
Fix for non-promoted team members not being displayed on GitHub Pages.

### DIFF
--- a/_layouts/teams.html
+++ b/_layouts/teams.html
@@ -42,7 +42,7 @@ bodyClass: "page-teams"
         {% endfor %}
     </div>
     <div class="row pt-6 pb-6">
-        {% assign teams = site.team | where: "promoted", empty | sort: "weight" %}
+        {% assign teams = site.team | where: "promoted", false | sort: "weight" %}
         {% for team in teams %}
         <div class="col-12 col-md-4 mb-3">
             <div class="team team-summary">

--- a/_team/bill-mcdonald.md
+++ b/_team/bill-mcdonald.md
@@ -5,6 +5,7 @@ draft: false
 image: "images/team/nonsap-visuals-kMJp7620W6U-unsplash.jpg"
 jobtitle: "Graphic Designer"
 linkedinurl: ""
+promoted: false
 weight: 7
 layout: team
 ---

--- a/_team/mike-vance.md
+++ b/_team/mike-vance.md
@@ -5,6 +5,7 @@ draft: false
 image: "images/team/joseph-gonzalez-399972-unsplash.jpg"
 jobtitle: "Art Director"
 linkedinurl: ""
+promoted: false
 weight: 3
 ---
 

--- a/_team/robert-johnson.md
+++ b/_team/robert-johnson.md
@@ -5,6 +5,7 @@ draft: false
 image: "images/team/vince-fleming-613817-unsplash.jpg"
 jobtitle: "Developer"
 linkedinurl: "https://www.linkedin.com/"
+promoted: false
 weight: 3
 ---
 

--- a/_team/susan-shelton.md
+++ b/_team/susan-shelton.md
@@ -3,6 +3,7 @@ title: "Susan Shelton"
 date: 2018-12-20T13:45:06+10:00
 draft: false
 image: "images/team/cristian-newman-94319-unsplash.jpg"
+promoted: false
 jobtitle: "Developer"
 weight: 5
 ---

--- a/_team/tamara-ells.md
+++ b/_team/tamara-ells.md
@@ -4,6 +4,7 @@ date: 2018-12-20T13:44:55+10:00
 draft: false
 image: "images/team/michael-dam-258165-unsplash.jpg"
 jobtitle: "UI Designer"
+promoted: false
 weight: 4
 ---
 


### PR DESCRIPTION
Fixes /team route for GitHub Pages

Here is my [fork](https://eldoritto.github.io/jekyll-serif-theme/team/) compared to [base](https://zerostaticthemes.github.io/jekyll-serif-theme/team/)