### PR TITLE
Use weighted_services on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -24,7 +24,8 @@ bodyClass: "page-home"
 <div class="strip">
   <div class="container pt-6 pb-6 pb-md-10">
     <div class="row justify-content-start">
-      {% for service in site.services %}
+      {% assign weighted_services = site.services | sort: "weight" %}
+      {% for service in weighted_services %}
       <div class="col-12 col-md-4 mb-1">
         <div class="service service-summary">
           <div class="service-content">


### PR DESCRIPTION
Hi,

At the moment, while /services/ sorts the different services by weight, the home page does not. This commit uses the same code on the services page on the home page as well to do that sorting, and makes behaviour more consistent.

Thanks!