### PR TITLE
Remove NPM stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# NPM
-node_modules
-npm-debug.log
-
 # Jekyll
 _site
 _site/


### PR DESCRIPTION
Why add it to `.gitignore`, we do not use NPM at all??